### PR TITLE
src/internal/translator: remove unnecessary join newline

### DIFF
--- a/src/internal/translator/translator.go
+++ b/src/internal/translator/translator.go
@@ -87,7 +87,7 @@ func (t *translator) TranslatePos(ctx context.Context, opt Option) ([]string, er
 			}
 			lines[i] = strings.TrimSpace(line)
 		}
-		text = strings.Join(lines, "\n")
+		text = strings.Join(lines, " ")
 	}
 
 	return t.translate(ctx, text, opt)


### PR DESCRIPTION
Remove unnecessary join newline.

I don't know when regression this problem, but I was debugging and results are here:

```diff
diff --git a/src/internal/translator/translator.go b/src/internal/translator/translator.go
index 143eeae..e4f8101 100644
--- a/src/internal/translator/translator.go
+++ b/src/internal/translator/translator.go
@@ -2,6 +2,7 @@ package translator
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
 
@@ -88,6 +89,7 @@ func (t *translator) TranslatePos(ctx context.Context, opt Option) ([]string, er
 			lines[i] = strings.TrimSpace(line)
 		}
 		text = strings.Join(lines, "")
+		t.vim.Command(fmt.Sprintf(`echomsg '%#v'`, text))
 	}
 
 	return t.translate(ctx, text, opt)
```

before:

![Screen Shot 2019-11-05 at 6 08 30 PM](https://user-images.githubusercontent.com/6366270/68194456-6a2fca80-fff8-11e9-8a2c-749184215b17.png)

after:

![Screen Shot 2019-11-05 at 6 08 05 PM](https://user-images.githubusercontent.com/6366270/68194490-761b8c80-fff8-11e9-998b-ef7159e533bb.png)
